### PR TITLE
Update snap_wrapper.c

### DIFF
--- a/src/snap_wrapper.c
+++ b/src/snap_wrapper.c
@@ -230,6 +230,7 @@ SEXP snap_bridging_R(SEXP sE, SEXP sn, SEXP sm, SEXP sMPI, SEXP srank) {
 #endif
     if (REAL(sBC) == NULL) {
         REprintf("Rank %d: error!\n", rank);
+        UNPROTECT(1);
         return NULL;
     }
   }


### PR DESCRIPTION
function snap_bridging_R is missing an UNPROTECT(1) in snap_wrapper.c, before returning from line 233. Made this fix.